### PR TITLE
Consistency for numpy int data types

### DIFF
--- a/examples/cosmo_box_gravity_only_3d/check.py
+++ b/examples/cosmo_box_gravity_only_3d/check.py
@@ -91,7 +91,7 @@ for i_file, z in enumerate(Redshifts):
         ax = plt.axes([0.1,0.1,0.87,0.87])
         
         if(pos.shape[0] > 32**3):
-            i_select = np.random.uniform(low=0.0, high=pos.shape[0], size=32**3).astype(np.int)
+            i_select = np.random.uniform(low=0.0, high=pos.shape[0], size=32**3).astype(np.int32)
         else:
             i_select = np.arange(pos.shape[0])
         ax.scatter(pos[i_select, 0], pos[i_select, 1], marker='.', s=0.05, alpha=0.5, rasterized=True)

--- a/examples/cosmo_box_gravity_only_3d/create.py
+++ b/examples/cosmo_box_gravity_only_3d/create.py
@@ -70,7 +70,7 @@ else:
 
 """ set output times z=1,0"""
 outputTimes = np.array([0.5, 1], dtype=np.float64)
-ones = np.ones(outputTimes.shape, dtype=np.int)
+ones = np.ones(outputTimes.shape, dtype=np.int32)
 
 
 """ write output list file """

--- a/examples/cosmo_box_star_formation_3d/check.py
+++ b/examples/cosmo_box_star_formation_3d/check.py
@@ -84,15 +84,15 @@ if makeplots:
         posstars = np.array(data["PartType4"]["Coordinates"], dtype = FloatType) / HubbleParam / 1000.
     
         if(pos.shape[0] > 32**3):
-            i_select = np.random.uniform(low=0.0, high=pos.shape[0], size=32**3).astype(np.int)
+            i_select = np.random.uniform(low=0.0, high=pos.shape[0], size=32**3).astype(np.int32)
         else:
             i_select = np.arange(pos.shape[0])
         ## Try to show the different gas phases and their spatial distribution
         z = 1./ a - 1
         if i == 0:
             continue
-        ax_col = np.int((i-1)%2)
-        ax_row = np.int((i-1)/2)
+        ax_col = np.int32((i-1)%2)
+        ax_row = np.int32((i-1)/2)
         print('col %d, row %d'%(ax_col, ax_row))
         print(ax[ax_col][ax_row])
         ax[ax_row][ax_col].text(5.5,10.0,'redshift %.1f'%z)
@@ -140,15 +140,15 @@ if makeplots:
         Density = np.array(data["PartType0"]["Density"], dtype = FloatType)
     
         if(pos.shape[0] > 32**3):
-            i_select = np.random.uniform(low=0.0, high=pos.shape[0], size=32**3).astype(np.int)
+            i_select = np.random.uniform(low=0.0, high=pos.shape[0], size=32**3).astype(np.int32)
         else:
             i_select = np.arange(pos.shape[0])
         ## Try to show the different gas phases and their spatial distribution
         z = 1./ a - 1
         if i == 0:
             continue
-        ax_col = np.int((i-1)%2)
-        ax_row = np.int((i-1)/2)
+        ax_col = np.int32((i-1)%2)
+        ax_row = np.int32((i-1)/2)
 
         Nplot = 512
         from scipy import spatial # needed for KDTree that we use for nearest neighbour search and Voronoi mesh

--- a/examples/cosmo_box_star_formation_3d/create.py
+++ b/examples/cosmo_box_star_formation_3d/create.py
@@ -64,7 +64,7 @@ else:
 
 """ set output times """
 outputTimes = np.array([0.2,0.25,0.33,0.5,0.66,1], dtype=np.float64)
-ones = np.ones(outputTimes.shape, dtype=np.int)
+ones = np.ones(outputTimes.shape, dtype=np.int32)
 
 """ copy treecool file to run directory """
 if len(sys.argv) > 2:

--- a/examples/cosmo_zoom_gravity_only_3d/create.py
+++ b/examples/cosmo_zoom_gravity_only_3d/create.py
@@ -33,7 +33,7 @@ print("create.py " + simulation_directory)
 
 """ output times """
 outputTimes = np.array([0.0197,0.2,0.25,0.33,0.5,0.66,1], dtype=np.float64)
-ones = np.ones(outputTimes.shape, dtype=np.int)
+ones = np.ones(outputTimes.shape, dtype=np.int32)
 data = np.array([outputTimes, ones]).T
 np.savetxt(simulation_directory+"/output_list.txt",data, fmt="%g %1.f" )
 
@@ -134,8 +134,8 @@ if runParent:
     print('Selected halo %d with position %g %g %g'%(i_halo, pos[0], pos[1], pos[2]))
                 
     # SELECTION OF PARTICLES IN HIGH-RES REGION
-    pid0 = np.array(sn0['PartType1']['ParticleIDs'], dtype=np.int64)
-    pid6 = np.array(sn6['PartType1']['ParticleIDs'], dtype=np.int64)
+    pid0 = np.array(sn0['PartType1']['ParticleIDs'], dtype=np.int32)
+    pid6 = np.array(sn6['PartType1']['ParticleIDs'], dtype=np.int32)
     ppos0 = np.array(sn0['PartType1']['Coordinates'], dtype=np.float64)
     ppos6 = np.array(sn6['PartType1']['Coordinates'], dtype=np.float64)
     

--- a/examples/galaxy_merger_star_formation_3d/check.py
+++ b/examples/galaxy_merger_star_formation_3d/check.py
@@ -74,8 +74,8 @@ for i_plot, i_snap in enumerate([10,11,12,21,22,24]):
     pos3 = np.array( data['PartType3']['Coordinates'], dtype=np.float64 )
     pos4 = np.array( data['PartType4']['Coordinates'], dtype=np.float64 )
     
-    ix = np.int(i_plot % 3)
-    iy = np.int(i_plot / 3)
+    ix = np.int32(i_plot % 3)
+    iy = np.int32(i_plot / 3)
     
     if makeplots:
         ax[iy,ix].scatter(pos2[:, 0], pos2[:, 1], marker='.', c='k', s=0.05, alpha=0.5, rasterized=True, zorder=2)

--- a/examples/galaxy_merger_star_formation_3d/create.py
+++ b/examples/galaxy_merger_star_formation_3d/create.py
@@ -22,7 +22,7 @@ print("create.py " + simulation_directory)
 
 """ set output times """
 outputTimes = np.linspace(0.0,3.0,32, dtype=np.float64)
-ones = np.ones(outputTimes.shape, dtype=np.int)
+ones = np.ones(outputTimes.shape, dtype=np.int32)
 
 
 """ write output list file """
@@ -46,13 +46,13 @@ res = call(["make", "CONFIG="+simulation_directory+"/Config_ADDBACKGROUNDGRID.sh
              "BUILD_DIR="+simulation_directory+"/build_ADDBACKGROUNDGRID", \
             "EXEC="+simulation_directory+"/Arepo_ADDBACKGRUNDGRID"])
 if res != 0:
-    sys.exit( np.int(res) )
+    sys.exit( np.int32(res) )
     
 ## execute Arepo with ADDBACKGROUNDGRID from run directory
 os.chdir(simulation_directory)
 res = call(["mpiexec", "-np", "1","./Arepo_ADDBACKGRUNDGRID", "./param_ADDBACKGROUNDGRID.txt"])
 if res != 0:
-    sys.exit( np.int(res) )
+    sys.exit( np.int32(res) )
 os.chdir(cwd)
 
 

--- a/examples/isolated_galaxy_collisionless_3d/create.py
+++ b/examples/isolated_galaxy_collisionless_3d/create.py
@@ -55,7 +55,7 @@ else:
 
 """ set output times """
 outputTimes = np.linspace(0.0,1.0,10, dtype=np.float64)
-ones = np.ones(outputTimes.shape, dtype=np.int)
+ones = np.ones(outputTimes.shape, dtype=np.int32)
 
 
 """ write output list file """


### PR DESCRIPTION
- `np.int` is deprecated in newer versions of numpy
![numpyinterror](https://github.com/jackmoore11/Arepo/assets/19765120/a70340d0-3aa0-463d-abfb-d189f5ee81cb)
- Updated instances of `np.int` and `np.int64` to use `np.int32`
